### PR TITLE
remove div wrapping around Animate

### DIFF
--- a/src/Animate.tsx
+++ b/src/Animate.tsx
@@ -20,5 +20,5 @@ export const Animate = ({
     let sub = propChanges.subscribe((newProps = {}) => setProps(newProps))
     return () => sub && sub.unsubscribe()
   }, [])
-  return <div>{React.createElement(component, props)}</div>
+  return React.createElement(component, props)
 }


### PR DESCRIPTION
this extra layer of div wrapping is messing up some of my css, so I was wondering if we can remove it. :) it should be easy for a caller to add a `div` layer if they need to.